### PR TITLE
fix filename typos

### DIFF
--- a/exercises/debug-activity/README.md
+++ b/exercises/debug-activity/README.md
@@ -127,7 +127,7 @@ layout.
      discount did not write a test case for it. 
      Deploying the untested code is what led to this failure, but 
      writing a test now will help you to verify the fix. 
-2. Open the `src/mocha/activity_test.ts` file in the editor
+2. Open the `src/mocha/activities.test.ts` file in the editor
 3. Add a new test by copying the existing `sends a bill for a typical order` test
    function and renaming the new function as `fails to send bill with negative amount`, and then make the following changes to it:
    * Change the `description` to `5 large cheese pizzas`

--- a/exercises/durable-execution/practice/src/activities.ts
+++ b/exercises/durable-execution/practice/src/activities.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-// TODO impport everything from the @temporalio/activity package as activity
+// TODO import everything from the @temporalio/activity package as activity
 
 import { TranslationActivityInput, TranslationActivityOutput } from './shared';
 

--- a/exercises/using-objects/README.md
+++ b/exercises/using-objects/README.md
@@ -22,7 +22,7 @@ what you've learned to do the same for the Activity.
 
 Before continuing with the steps below, take a moment to look at the code in
 the `src/shared.ts` file to see how the types are defined for the Workflow.
-After this, look at the `src/workflow.ts` file to see how these values are passed
+After this, look at the `src/workflows.ts` file to see how these values are passed
 in and used in the Workflow code. Finally, look at the `src/client.ts` to see
 how the input parameters are created and passed into the Workflow.
 


### PR DESCRIPTION
minor filename typos (these are from my notes while at replay, didn't get around to contributing them until now)